### PR TITLE
Parroco controller and router

### DIFF
--- a/arquidiocesis-back/index.js
+++ b/arquidiocesis-back/index.js
@@ -5,6 +5,7 @@ const express = require('express');
 const app = express();
 const PORT = process.env.PORT || 8000;
 const cors = require('cors');
+const Parroco = require('./routes/parroco/router');
 const parroquias = require('./routes/parroquia');
 const decanato = require('./routes/decanato');
 const login = require('./routes/login');
@@ -90,6 +91,8 @@ app.post('/api/admin/users/delete', (req, res) =>
 app.post('/api/admin/users/edit', (req, res) =>
   admins.editUserDetail(firestore, req, res)
 );
+
+app.use('/api/parrocos', Parroco);
 
 app.get('/api/parroquias', (req, res) => {
   parroquias.getall(firestore, req, res);

--- a/arquidiocesis-back/package.json
+++ b/arquidiocesis-back/package.json
@@ -31,6 +31,7 @@
     "jsonwebtoken": "^8.5.1",
     "make-runnable": "^1.3.8",
     "moment": "^2.25.1",
+    "moment-timezone": "^0.5.33",
     "multer": "^1.4.2",
     "npmi": "^4.0.0",
     "prolly": "^0.5.4",

--- a/arquidiocesis-back/routes/parroco/controller.js
+++ b/arquidiocesis-back/routes/parroco/controller.js
@@ -1,0 +1,305 @@
+/**
+ * Module for managing parrocos
+ * @module Parroco
+ */
+const bcrypt = require('bcrypt-nodejs');
+const moment = require('moment-timezone');
+const admin = require('firebase-admin');
+
+/**
+ * Gets all the documents in the 'parrocos' collection
+ * @param {firebase.firestore} firestore - preinitialized admin-firebase.firestore() instance
+ * @param {POST} req
+ * @param {String} req.body.token
+ *
+ * @param {JSON} res - Status 200
+ * @param {Bool} res.error - True if there was an error else false
+ * @param {String} [res.message] - only assigned if there was an error, contains the error message
+ * @param {Parroco[]} [res.data] - If there was no error, will be assigned
+ * @param {String} res.data[].id
+ * @param {String} res.data[].nombre
+ * @param {String} res.data[].apellido_paterno
+ * @param {String} res.data[].apellido_materno
+ */
+exports.getAll = async (firestore, req, res) => {
+  try {
+    const snapshot = await firestore.collection('parrocos').get();
+    const docs = snapshot.docs.map((doc) => {
+      return {
+        id: doc.id,
+        nombre: doc.data().nombre,
+        apellido_paterno: doc.data().apellido_paterno,
+        apellido_materno: doc.data().apellido_materno,
+      };
+    });
+    res.send({
+      error: false,
+      data: docs,
+    });
+  } catch (err) {
+    res.send({
+      error: true,
+      message: 'Error inesperado al obtener párrocos.',
+    });
+  }
+};
+
+/**
+ * Gets the document in the 'parrocos' collection with the provided information in the request.body
+ * @param {firebase.firestore} firestore - preinitialized admin-firebase.firestore() instance
+ * @param {POST} req
+ * @param {String} req.body.token
+ * @param {String} req.params.id
+ *
+ * @param {JSON} res - Status 200
+ * @param {Bool} res.error - True if there was an error else false
+ * @param {String} [res.message] - only assigned if there was an error, contains the error message
+ * @param {Parroco[]} [res.data] - If there was no error, will be assigned
+ * @param {String} res.data[].id
+ * @param {String} res.data[].nombre
+ * @param {String} res.data[].apellido_paterno
+ * @param {String} res.data[].apellido_materno
+ */
+exports.getOne = async (firestore, req, res) => {
+  try {
+    const snapshot = await firestore
+      .collection('parrocos')
+      .doc(req.params.id)
+      .get();
+    if (!snapshot.exists)
+      return res.send({
+        error: true,
+        message: 'Párroco no existe.',
+      });
+
+    const parroco = snapshot.data();
+    parroco.id = snapshot.id;
+    // TODO: (kike) Ask what it's going to be associated to parroco.
+    // parroco.grupos = [];
+    // parroco.decanatos = [];
+    // parroco.parroquias = [];
+    // parroco.capillas = [];
+    return res.send({
+      error: false,
+      data: parroco,
+    });
+  } catch (err) {
+    res.send({
+      error: true,
+      message: 'Error inesperado al obtener párroco.',
+    });
+  }
+};
+
+/**
+ * Adds a new document in the 'parrocos' and 'logins' collections with the provided information in the request.body
+ * @param {firebase.firestore} firestore - preinitialized admin-firebase.firestore() instance
+ * @param {POST} req
+ * @param {String} req.body.token
+ * @param {String} req.body.nombre
+ * @param {String} req.body.apellido_paterno
+ * @param {String} req.body.apellido_materno
+ * @param {String} req.body.email
+ * @param {String} req.body.password
+ * @param {String} req.body.fecha_nacimiento
+ * @param {String} req.body.fecha_ordenamiento
+ * @param {String} req.body.telefono_movil
+ *
+ * @param {JSON} res - Status 200
+ * @param {Bool} res.error - True if there was an error else false
+ * @param {String} [res.message] - only assigned if there was an error, contains the error message
+ * @param {JSON} [res.data] - If there was no error, will be be assigned
+ * @param {String} res.data.nombre
+ * @param {String} res.data.apellido_paterno
+ * @param {String} res.data.apellido_materno
+ * @param {String} res.data.email
+ * @param {String} res.data.fecha_nacimiento
+ * @param {String} res.data.fecha_ordenamiento
+ * @param {String} res.data.telefono_movil
+ */
+exports.add = async (firestore, req, res) => {
+  const {
+    nombre,
+    apellido_paterno,
+    apellido_materno,
+    email,
+    password,
+    fecha_nacimiento,
+    fecha_ordenamiento,
+    telefono_movil,
+  } = req.body;
+
+  if (!req.user.admin) {
+    return res.send({
+      error: true,
+      code: 999,
+      message: 'No tienes acceso a esta acción.',
+    });
+  }
+
+  try {
+    const checkEmail = await firestore
+      .collection('logins')
+      .doc(email.toLowerCase())
+      .get();
+    if (checkEmail.exists)
+      return res.send({
+        error: true,
+        code: 1,
+        message: 'Correo ya utilizado.',
+      });
+
+    let fn = moment(fecha_nacimiento, 'YYYY-MM-DD')
+      .tz('America/Monterrey')
+      .startOf('day');
+    if (!fn.isValid()) fn = moment();
+
+    let fo = moment(fecha_ordenamiento, 'YYYY-MM-DD')
+      .tz('America/Monterrey')
+      .startOf('day');
+    if (!fo.isValid()) fo = moment();
+
+    // TODO: (kike) Check if there is an id for parroco.
+    // // Validate if a coordinador with identificador exists
+    // const coordinador = await firestore
+    //   .collection('coordinadores')
+    //   .where('identificador', '==', identificador)
+    //   .get();
+    // if (!coordinador.empty) {
+    //   return res.send({
+    //     error: true,
+    //     message: 'Ya existe un coordinador con el identificador proporcionado.',
+    //   });
+    // }
+
+    const newParroco = {
+      nombre,
+      apellido_paterno,
+      apellido_materno,
+      email,
+      fecha_nacimiento: fn,
+      fecha_ordenamiento: fo,
+      telefono_movil,
+    };
+
+    const newLogin = {
+      password: bcrypt.hashSync(password),
+      tipo: 'parroco',
+      id: null,
+    };
+
+    const docref = await firestore.collection('parrocos').add(newParroco);
+    newLogin.id = docref.id;
+    await firestore.collection('logins').doc(email.toLowerCase()).set(newLogin);
+
+    const new_user = await firestore.collection('users').add(newParroco);
+    const role = await firestore.collection('roles').doc('parroco');
+
+    await role.update({
+      members: admin.firestore.FieldValue.arrayUnion(...[new_user.id]),
+    });
+
+    return res.send({
+      error: false,
+      data: {
+        id: docref.id,
+        ...newParroco,
+      },
+    });
+  } catch (e) {
+    return res.send({
+      error: true,
+      message: 'Error inesperado al agregar párroco.',
+    });
+  }
+};
+
+/**
+ * Edits a document in the 'parrocos' collections with the provided information in the request.body
+ * @param {firebase.firestore} firestore - preinitialized admin-firebase.firestore() instance
+ * @param {POST} req
+ * @param {String} req.body.token
+ * @param {String} req.body.nombre
+ * @param {String} req.body.apellido_paterno
+ * @param {String} req.body.apellido_materno
+ * @param {String} req.body.email
+ * @param {String} req.body.password
+ * @param {String} req.body.fecha_nacimiento
+ * @param {String} req.body.fecha_ordenamiento
+ * @param {String} req.body.telefono_movil
+ *
+ * @param {JSON} res - Status 200
+ * @param {Bool} res.error - True if there was an error else false
+ * @param {String} [res.message] - only assigned if there was an error, contains the error message
+ * @param {Boolean} [res.data] - If there was no error, will be be assigned
+ */
+exports.edit = async (firestore, req, res) => {
+  const {
+    nombre,
+    apellido_paterno,
+    apellido_materno,
+    fecha_nacimiento,
+    fecha_ordenamiento,
+    telefono_movil,
+  } = req.body;
+
+  if (!req.user.admin) {
+    return res.send({
+      error: true,
+      code: 999,
+      message: 'No tienes acceso a esta acción.',
+    });
+  }
+
+  try {
+    const ref = firestore.collection('parrocos').doc(req.params.id);
+    const snapshot = await ref.get();
+    if (!snapshot.exists)
+      return res.send({
+        error: true,
+        message: 'Párroco no existe.',
+      });
+
+    let fn = moment(fecha_nacimiento, 'YYYY-MM-DD')
+      .tz('America/Monterrey')
+      .startOf('day');
+    if (!fn.isValid()) fn = moment();
+
+    let fo = moment(fecha_ordenamiento, 'YYYY-MM-DD')
+      .tz('America/Monterrey')
+      .startOf('day');
+    if (!fo.isValid()) fo = moment();
+
+    // TODO: (kike) Check if there is an id for parroco.
+    // // Validate if a coordinador with identificador exists
+    // const coordinador = await firestore
+    //   .collection('coordinadores')
+    //   .where('identificador', '==', identificador)
+    //   .get();
+    // if (!coordinador.empty) {
+    //   return res.send({
+    //     error: true,
+    //     message: 'Ya existe un coordinador con el identificador proporcionado.',
+    //   });
+    // }
+
+    const editParroco = {
+      nombre,
+      apellido_paterno,
+      apellido_materno,
+      fecha_nacimiento: fn,
+      fecha_ordenamiento: fo,
+      telefono_movil,
+    };
+    await ref.update(editParroco);
+    return res.send({
+      error: false,
+      data: true,
+    });
+  } catch (e) {
+    return res.send({
+      error: true,
+      message: 'Error inesperado al agregar párroco.',
+    });
+  }
+};

--- a/arquidiocesis-back/routes/parroco/router.js
+++ b/arquidiocesis-back/routes/parroco/router.js
@@ -1,0 +1,26 @@
+/**
+ * Module for managing 'Parrocos'
+ * @module Parroco
+ */
+const router = require('express').Router();
+const firestore = require('../../firebase/setup').firestore();
+const controller = require('./controller');
+
+// Routes
+router.get('/', (req, res) => {
+  controller.getAll(firestore, req, res);
+});
+
+router.get('/:id', (req, res) => {
+  controller.getOne(firestore, req, res);
+});
+
+router.post('/', (req, res) => {
+  controller.add(firestore, req, res);
+});
+
+router.put('/:id', (req, res) => {
+  controller.edit(firestore, req, res);
+});
+
+module.exports = router;

--- a/arquidiocesis-back/yarn.lock
+++ b/arquidiocesis-back/yarn.lock
@@ -5746,7 +5746,14 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.25.1:
+moment-timezone@^0.5.33:
+  version "0.5.33"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
+  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.25.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
Adds the Parroco controller and router. Using another structure compared to the one that was used before.

Instead of putting everything in `index.js`, for each _component_ there must be a folder to have the controller and router for it. That way is cleaner and easier to find code.

## Parroco
Currently it supports:
* Get all parrocos
* Get one parroco (based on id)
* Add parroco
* Edit parroco (based on id)

There are still somethings to be added (or not), depending on the clients needs. Like adding the parroquias, groups, and so on, on the Get One Parroco.